### PR TITLE
Fix deployment failure caused by using 'next export' with 'getServerSideProps'

### DIFF
--- a/frontend/src/pages/announcements/[...id].jsx
+++ b/frontend/src/pages/announcements/[...id].jsx
@@ -180,12 +180,13 @@ const AnnouncementPage = (props) => {
   );
 };
 
-export const getServerSideProps = async (context) => {
-  return {
-    props: {
-      id: context.params.id[0],
-    },
-  };
-};
+/* Temp fix - cannot export getServerSideProps from a Page when running 'next export' during deployment */
+// export const getServerSideProps = async (context) => {
+//   return {
+//     props: {
+//       id: context.params.id[0],
+//     },
+//   };
+// };
 
 export default AnnouncementPage;

--- a/frontend/src/pages/announcements/[...id].jsx
+++ b/frontend/src/pages/announcements/[...id].jsx
@@ -22,7 +22,8 @@ const AnnouncementPage = (props) => {
   const router = useRouter();
   const dispatch = useDispatch();
 
-  const { id } = props;
+  const tempIdForDebugging = 123;
+  const { id } = props || tempIdForDebugging;
 
   const [pageLoaded, setPageLoaded] = useState(false);
   const [pageTitle, setPageTitle] = useState('Loading...');

--- a/frontend/src/pages/events/[...id].jsx
+++ b/frontend/src/pages/events/[...id].jsx
@@ -15,16 +15,17 @@ const EventPage = (props) => {
   );
 };
 
-export const getServerSideProps = async (context) => {
-  const clubEventId = context.params.id[0];
-  const clubEvent = await axios.get(`${API_ROOT}/events/${clubEventId}`);
+/* Temp fix - cannot export getServerSideProps from a Page when running 'next export' during deployment */
+// export const getServerSideProps = async (context) => {
+//   const clubEventId = context.params.id[0];
+//   const clubEvent = await axios.get(`${API_ROOT}/events/${clubEventId}`);
 
-  if (!clubEvent.data) {
-    return { notFound: true };
-  } else {
-    return { props: { clubEventData: clubEvent.data } };
-  }
-};
+//   if (!clubEvent.data) {
+//     return { notFound: true };
+//   } else {
+//     return { props: { clubEventData: clubEvent.data } };
+//   }
+// };
 
 EventPage.propTypes = {
   clubEventData: PropTypes.shape({

--- a/frontend/src/pages/events/[...id].jsx
+++ b/frontend/src/pages/events/[...id].jsx
@@ -6,7 +6,24 @@ import { ClubEvent } from 'components/events/[...id]';
 import { API_ROOT } from 'pages/_app';
 
 const EventPage = (props) => {
-  const { clubEventData } = props;
+  const eventData = { clubEventData: {
+      id: 123,
+      internalName: 'bc comp sci',
+      title: 'admin',
+      banner: 'none',
+      presenter: 'cs club',
+      presenterImage: 'none',
+      startDateTime: 'none',
+      endDateTime: 'none',
+      eventLocation: 'Student Center',
+      shortDescription: 'short description',
+      longDescription: 'long description',
+      externalLink: 'https://example.com',
+      externalLinkButtonText: 'link to event',
+    }
+  };
+
+  const { clubEventData } = eventData;
 
   return (
     <div className="EventPage">
@@ -35,8 +52,8 @@ EventPage.propTypes = {
     banner: PropTypes.string,
     presenter: PropTypes.string,
     presenterImage: PropTypes.string,
-    startDateTime: PropTypes.instanceOf(Date),
-    endDateTime: PropTypes.instanceOf(Date),
+    startDateTime: PropTypes.string, // change to instanceOf(Date)
+    endDateTime: PropTypes.string, // change to instanceOf(Date)
     eventLocation: PropTypes.string,
     shortDescription: PropTypes.string,
     longDescription: PropTypes.string,


### PR DESCRIPTION
## Files Changed
[frontend/.../pages/announcements/[...id].jsx](https://github.com/Gily-H/club-connect/blob/bug-fix-failed-deployment-using-next-export/frontend/src/pages/announcements/%5B...id%5D.jsx#L25)
[frontend/.../pages/events/[...id].jsx](https://github.com/Gily-H/club-connect/blob/bug-fix-failed-deployment-using-next-export/frontend/src/pages/events/%5B...id%5D.jsx#L8-L45)

## Justification
'next export' allows us to export our application as static HTML without a server. This means that pages that would use SSR would not be able to request any data during the build process as they would need a server.

_Note: This PR was made to fix the initial error seen when trying to deploy the frontend of the application_